### PR TITLE
Fix weird rotations, a way to disable smoothening

### DIFF
--- a/src/main/java/boatcam/BoatCamMod.java
+++ b/src/main/java/boatcam/BoatCamMod.java
@@ -153,7 +153,7 @@ public class BoatCamMod implements ModInitializer, LookDirectionChangingEvent {
 	private void calculateYaw(ClientPlayerEntity player, BoatEntity boat) {
 		// yaw calculations
 		float yaw = boat.getYaw();
-		if (boatPos != null) {
+		if (boatPos != null && getConfig().getSmoothness() < 1) {
 			double dz = boat.getZ() - boatPos.z, dx = boat.getX() - boatPos.x;
 			if (dx != 0 || dz != 0) {
 				float vel = (float) hypot(dz, dx);
@@ -162,7 +162,7 @@ public class BoatCamMod implements ModInitializer, LookDirectionChangingEvent {
 				yaw = AngleUtil.lerp(t, yaw, direction);
 			}
 			yaw = AngleUtil.lerp(getConfig().getSmoothness(), previousYaw, yaw);
-		}
+        }
 		player.setYaw(yaw);
 		// save pos and yaw
 		previousYaw = yaw;

--- a/src/main/java/boatcam/BoatCamMod.java
+++ b/src/main/java/boatcam/BoatCamMod.java
@@ -126,6 +126,7 @@ public class BoatCamMod implements ModInitializer, LookDirectionChangingEvent {
 		} else {
 			// first tick after disabling boat mode or leaving boat
 			if (perspective != null) {
+                boatPos = null;
 				resetPerspective();
 				// invert pitch if looking behind
 				if (lookingBehind) {

--- a/src/main/java/boatcam/config/BoatCamConfig.java
+++ b/src/main/java/boatcam/config/BoatCamConfig.java
@@ -11,7 +11,7 @@ import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 public final class BoatCamConfig implements ConfigData {
     @Comment("Whether the camera should be controlled by this mod or not.\nNOTE: This setting can be toggled using a key bind.")
     private boolean boatMode = false;
-    @Comment("1 - Smooth camera, might even lag behind.\n100 - Camera angle might change very abruptly.")
+    @Comment("1 - Smooth camera, might even lag behind.\n100 - Disable smoothening.")
     @BoundedDiscrete(min = 1, max = 100)
     private int smoothness = 50;
     @Comment("Perspective when riding a boat in boat mode. Perspective wont change when this is set to none.")


### PR DESCRIPTION
Hello! This pull request proposes 2 changes:
- Resets `boatPos` after exiting a boat
- Disables smoothening if smoothness is set to 100

In some cases, if `boatPos` is not reset, when entering a new boat the player will try to rotate according to the old position and also rotate the boat (for some reason). Simply resetting `boatPos` to `null` when exiting the boat fixes this.

Smoothening can be not desired by some users of the mod, for example when playing competitively smoothening can be a distraction, so I added a way to disable it by setting smoothness to 100.

Thanks for this great mod!